### PR TITLE
多列picker里如果每列的valueMember有重复的话displayRender会有一个bug，类似下面的情况

### DIFF
--- a/components/Picker/Picker.jsx
+++ b/components/Picker/Picker.jsx
@@ -216,11 +216,12 @@ class Picker extends Component {
         }
       }
 
-      let treeChildren2 = this.props.dataSource.reduce((a, b) => {
-        return a.concat(b);
-      }, []);
-      treeChildren2 = treeChildren2.filter((item) => { return ~value.indexOf(item[valueMember]); });
-
+      const treeChildren2 = data.map((d, index) => {
+        if (value[index]) {
+          return d.find(obj => value[index] === obj[valueMember]);
+        }
+        return undefined;
+      }).filter(t => !!t);
       return this._displayRender(treeChildren2);
     };
 


### PR DESCRIPTION
```jsx
<Picker
      dataSource={[
                    [
                      { value: '1', label: '选项一' },
                      { value: '2', label: '选项二' },
                    ],
                    [
                      { value: '1', label: '选项A' },
                      { value: 'b', label: '选项B' },
                    ],
       ]}
   />
```