### PR TITLE
picker 的初始值在异步获取的情况下，点击取消后 value丢失的bug

### DIFF
--- a/components/Picker/DatePicker.jsx
+++ b/components/Picker/DatePicker.jsx
@@ -58,6 +58,7 @@ class DatePicker extends Component {
     this.setState({
       date: date || defaultDate,
     });
+    this.initDate = date || defaultDate
   }
 
   // 点击遮罩层

--- a/components/Picker/DatePicker.jsx
+++ b/components/Picker/DatePicker.jsx
@@ -58,7 +58,7 @@ class DatePicker extends Component {
     this.setState({
       date: date || defaultDate,
     });
-    this.initDate = date || defaultDate
+    this.initDate = date || defaultDate;
   }
 
   // 点击遮罩层

--- a/components/Picker/Picker.jsx
+++ b/components/Picker/Picker.jsx
@@ -71,6 +71,7 @@ class Picker extends Component {
         value: _value,
         cascade: dataSource.length && !isArray(dataSource[0]) && hasChildrenObject(dataSource[0]),
       });
+      this.tempValue = _value;
     }
   }
 


### PR DESCRIPTION
```js
componentDidMount(){
 setTimeout(() => {
     this.setState({
     value:'2010-01-01'
   })
 }, 100)
}
<Picker.Date
    title="选择日期"
    placeholder="请选择日期"
    mode="date"
    value={this.state.value}/>
```
这个时候调出picker 点击取消，应该可以重现这个问题