### PR TITLE
修复页面跳转 demo页面中的组件不能自动卸载的问题

### DIFF
--- a/components/loading/index.tsx
+++ b/components/loading/index.tsx
@@ -14,12 +14,32 @@ export default class Loading extends PureComponent<LoadingProps, {}> {
     prefixCls: 'za-loading',
   };
 
+  static zarmLoading: HTMLElement;
+  static isShow: boolean;
   static show = (props) => {
-    ReactDOM.render(<Loading {...props} visible />, window.zarmLoading);
+    if (!Loading.zarmLoading) {
+      Loading.zarmLoading = document.createElement('div');
+    }
+    document.body.appendChild(Loading.zarmLoading);
+    ReactDOM.render(<Loading {...props} visible />, Loading.zarmLoading);
+    Loading.isShow = true;
   }
 
   static hide = () => {
-    ReactDOM.render(<Loading visible={false} />, window.zarmLoading);
+    ReactDOM.render(<Loading
+      visible={false}
+      onClose={Loading.unmountNode}
+    />, Loading.zarmLoading);
+  }
+
+  static unmountNode() {
+    const { zarmLoading } = Loading;
+    if (zarmLoading) {
+      ReactDOM.unmountComponentAtNode(zarmLoading);
+      if (zarmLoading.parentNode) {
+        zarmLoading.parentNode.removeChild(Loading.zarmLoading);
+      }
+    }
   }
 
   render() {
@@ -31,13 +51,4 @@ export default class Loading extends PureComponent<LoadingProps, {}> {
       </Toast>
     );
   }
-}
-
-if (typeof window !== 'undefined') {
-  if (!window.zarmLoading) {
-    window.zarmLoading = document.createElement('div');
-    document.body.appendChild(window.zarmLoading);
-  }
-
-  ReactDOM.render(<Loading visible={false} />, window.zarmLoading);
 }

--- a/components/toast/demo.md
+++ b/components/toast/demo.md
@@ -85,6 +85,9 @@ class Demo extends React.Component {
               size="sm"
               onClick={() => {
                 Loading.show();
+                setTimeout(()=>{
+                  Loading.hide();
+                }, 1000);
               }}
             >
               开启

--- a/components/toast/demo.md
+++ b/components/toast/demo.md
@@ -87,7 +87,7 @@ class Demo extends React.Component {
                 Loading.show();
                 setTimeout(()=>{
                   Loading.hide();
-                }, 1000);
+                }, 1100);
               }}
             >
               开启

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -20,7 +20,7 @@ export default class Toast extends PureComponent<ToastProps, any> {
   static show = (children: any, stayTime?: number, onClose?: () => void) => {
     ReactDOM.render(
       <Toast visible stayTime={stayTime} onClose={onClose}>{children}</Toast>
-    , window.zarmToast);
+      , window.zarmToast);
   }
 
   static hide = () => {
@@ -48,7 +48,7 @@ export default class Toast extends PureComponent<ToastProps, any> {
     if (nextProps.visible) {
       this.enter(nextProps);
     } else {
-      this.leave();
+      this.leave(nextProps);
     }
   }
 
@@ -71,17 +71,17 @@ export default class Toast extends PureComponent<ToastProps, any> {
       if (typeof onMaskClick === 'function') {
         onMaskClick();
       }
-      this.leave();
+      this.leave(props);
       clearTimeout(this.timer);
     }, stayTime);
   }
 
-  leave = () => {
+  leave = (props) => {
     this.setState({
       visible: false,
     });
 
-    const { onClose } = this.props;
+    const { onClose } = props;
     if (typeof onClose === 'function') {
       onClose();
     }

--- a/examples/components/Demo.jsx
+++ b/examples/components/Demo.jsx
@@ -17,6 +17,12 @@ export default class Demo extends React.Component {
     this.renderSource(this.source[2]);
   }
 
+  componentWillUnmount() {
+    if (this.containerElem) {
+      ReactDOM.unmountComponentAtNode(this.containerElem);
+    }
+  }
+
   renderSource(value) {
     import('../../components').then((Element) => {
       const args = ['context', 'React', 'ReactDOM', 'zarm'];
@@ -55,10 +61,10 @@ export default class Demo extends React.Component {
   render() {
     // Panel的例子特殊处理
     return (this.props.location.pathname === '/panel')
-      ? <div id={this.containerId} />
+      ? <div id={this.containerId} ref={(elem) => { this.containerElem = elem; }} />
       : (
         <Panel titleRender={<span>{this.title}</span>}>
-          <div id={this.containerId} />
+          <div id={this.containerId} ref={(elem) => { this.containerElem = elem; }} />
         </Panel>
       );
   }

--- a/examples/components/Markdown.jsx
+++ b/examples/components/Markdown.jsx
@@ -24,11 +24,19 @@ export default class Markdown extends React.Component {
     this.renderDOM();
   }
 
+  componentWillUnmount() {
+    this.nodeList.forEach((node) => {
+      ReactDOM.unmountComponentAtNode(node);
+    });
+  }
+
+  nodeList = [];
+
   renderDOM() {
     // eslint-disable-next-line
     for (const [id, component] of this.components) {
       const div = document.getElementById(id);
-
+      this.nodeList.push(div);
       if (div instanceof HTMLElement) {
         ReactDOM.render(component, div);
       }


### PR DESCRIPTION
+ 修复页面间跳转 demo中的组件不能自动卸载的问题，主要是由于在 markdown.jsx和Demo.jsx中未处理页组件卸载。
+ 修改了 Loading的加载方式，使用动态创建的方式进行挂载。