### PR TITLE
refactor: carousel

### DIFF
--- a/components/carousel/PropsType.tsx
+++ b/components/carousel/PropsType.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, CSSProperties } from 'react';
 
 export default interface PropsType {
   direction?: 'left' | 'right' | 'top' | 'bottom';
@@ -14,4 +14,5 @@ export default interface PropsType {
   onChange?: (activeIndex: number) => void;
   onChangeEnd?: (activeIndex: number) => void;
   children: ReactNode[];
+  style?: CSSProperties;
 }

--- a/components/carousel/__tests__/__snapshots__/index.test.jsx.snap
+++ b/components/carousel/__tests__/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,123 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Carousel loop renders correctly 1`] = `
+exports[`Carousel base render correctly 1`] = `
+<div>
+  <div
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    >
+      <div
+        class="za-carousel-item"
+      >
+        0
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        1
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        2
+      </div>
+    </div>
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul>
+        <li
+          class="active"
+          role="tab"
+          style="display:inline-block"
+        />
+        <li
+          class=""
+          role="tab"
+          style="display:inline-block"
+        />
+        <li
+          class=""
+          role="tab"
+          style="display:inline-block"
+        />
+      </ul>
+    </div>
+  </div>
+  <div
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    />
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul />
+    </div>
+  </div>
+  <div
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    />
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul />
+    </div>
+  </div>
+  <div
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    >
+      <div
+        class="za-carousel-item"
+      >
+        0
+      </div>
+    </div>
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul>
+        <li
+          class="active"
+          role="tab"
+          style="display:inline-block"
+        />
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Carousel className render correctly 1`] = `
+<div
+  class="za-carousel za-wrapper-test"
+>
+  <div
+    class="za-carousel-items"
+    style="white-space:nowrap"
+  />
+  <div
+    class="za-carousel-pagination horizontal"
+  >
+    <ul />
+  </div>
+</div>
+`;
+
+exports[`Carousel componentWillReceiveProps 1`] = `
 <div
   class="za-carousel"
 >
@@ -11,11 +128,6 @@ exports[`Carousel loop renders correctly 1`] = `
     <div
       class="za-carousel-item"
     >
-      3
-    </div>
-    <div
-      class="za-carousel-item"
-    >
       1
     </div>
     <div
@@ -23,33 +135,18 @@ exports[`Carousel loop renders correctly 1`] = `
     >
       2
     </div>
-    <div
-      class="za-carousel-item"
-    >
-      3
-    </div>
-    <div
-      class="za-carousel-item"
-    >
-      1
-    </div>
   </div>
   <div
     class="za-carousel-pagination horizontal"
   >
     <ul>
       <li
+        class=""
+        role="tab"
+        style="display:inline-block"
+      />
+      <li
         class="active"
-        role="tab"
-        style="display:inline-block"
-      />
-      <li
-        class=""
-        role="tab"
-        style="display:inline-block"
-      />
-      <li
-        class=""
         role="tab"
         style="display:inline-block"
       />
@@ -58,14 +155,19 @@ exports[`Carousel loop renders correctly 1`] = `
 </div>
 `;
 
-exports[`Carousel renders correctly 1`] = `
+exports[`Carousel height render correctly 1`] = `
 <div
   class="za-carousel"
 >
   <div
     class="za-carousel-items"
-    style="white-space:nowrap"
+    style="height:150px"
   >
+    <div
+      class="za-carousel-item"
+    >
+      0
+    </div>
     <div
       class="za-carousel-item"
     >
@@ -76,14 +178,118 @@ exports[`Carousel renders correctly 1`] = `
     >
       2
     </div>
+  </div>
+  <div
+    class="za-carousel-pagination vertical"
+  >
+    <ul>
+      <li
+        class="active"
+        role="tab"
+      />
+      <li
+        class=""
+        role="tab"
+      />
+      <li
+        class=""
+        role="tab"
+      />
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`Carousel pagination render correctly 1`] = `
+<div>
+  <div
+    class="za-carousel"
+  >
     <div
-      class="za-carousel-item"
+      class="za-carousel-items"
+      style="white-space:nowrap"
     >
-      3
+      <div
+        class="za-carousel-item"
+      >
+        0
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        1
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        2
+      </div>
+    </div>
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul>
+        <li
+          class="active"
+          role="tab"
+          style="display:inline-block"
+        />
+        <li
+          class=""
+          role="tab"
+          style="display:inline-block"
+        />
+        <li
+          class=""
+          role="tab"
+          style="display:inline-block"
+        />
+      </ul>
     </div>
   </div>
   <div
-    class="za-carousel-pagination horizontal"
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    >
+      <div
+        class="za-carousel-item"
+      >
+        0
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        1
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        2
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Carousel prefixCls render correctly 1`] = `
+<div
+  class="za-test"
+>
+  <div
+    class="za-test-items"
+    style="white-space:nowrap"
+  >
+    <div
+      class="za-test-item"
+    >
+      0
+    </div>
+  </div>
+  <div
+    class="za-test-pagination horizontal"
   >
     <ul>
       <li
@@ -91,17 +297,23 @@ exports[`Carousel renders correctly 1`] = `
         role="tab"
         style="display:inline-block"
       />
-      <li
-        class=""
-        role="tab"
-        style="display:inline-block"
-      />
-      <li
-        class=""
-        role="tab"
-        style="display:inline-block"
-      />
     </ul>
+  </div>
+</div>
+`;
+
+exports[`Carousel style render correctly 1`] = `
+<div
+  class="za-carousel"
+>
+  <div
+    class="za-carousel-items"
+    style="background:red;white-space:nowrap"
+  />
+  <div
+    class="za-carousel-pagination horizontal"
+  >
+    <ul />
   </div>
 </div>
 `;

--- a/components/carousel/__tests__/index.test.jsx
+++ b/components/carousel/__tests__/index.test.jsx
@@ -1,96 +1,139 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { render, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import Carousel from '../index';
 
+const createCarousel = (props, childrenLen = 3) => {
+  const ITEMS = Array.from({ length: childrenLen }).map((v, i) => i);
+  return (
+    <Carousel {...props}>
+      {
+        ITEMS.map((item, index) => {
+          return (
+            <div key={index}>{ item }</div>
+          );
+        })
+      }
+    </Carousel>
+  );
+};
+
 describe('Carousel', () => {
-  it('renders correctly', () => {
-    const ITEMS = ['1', '2', '3'];
+  it('base render correctly', () => {
     const wrapper = render(
-      <Carousel>
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
+      <div>
+        { createCarousel() }
+        { createCarousel({}, 0) }
+        { createCarousel({ activeIndex: 1 }, 0) }
+        { createCarousel({}, 1) }
+      </div>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
-  it('loop renders correctly', () => {
-    const ITEMS = ['1', '2', '3'];
+  it('style render correctly', () => {
+    const style = { background: 'red' };
+    const wrapper = render(createCarousel({ style }, 0));
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('prefixCls render correctly', () => {
+    const prefixCls = 'za-test';
+    const wrapper = render(createCarousel({ prefixCls }, 1));
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('className render correctly', () => {
+    const className = 'za-wrapper-test';
+    const wrapper = render(createCarousel({ className }, 0));
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('height render correctly', () => {
+    const wrapper = render(createCarousel({ height: 150, direction: 'top' }));
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('pagination render correctly', () => {
     const wrapper = render(
-      <Carousel loop>
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
+      <div>
+        {createCarousel({ showPagination: true })}
+        {createCarousel({ showPagination: false })}
+      </div>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('activeIndex', () => {
+    const wrapper = mount(createCarousel({ activeIndex: 1 }));
+    expect(wrapper.state('activeIndex')).toEqual(1);
   });
 
   it('autoPlay', () => {
     jest.useFakeTimers();
-    const ITEMS = ['1', '2', '3'];
     const onChange = jest.fn();
-    const wrapper = mount(
-      <Carousel
-        autoPlay
-        onChange={onChange}
-      >
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
-    );
-    wrapper.setProps({ activeIndex: 1 });
-    jest.advanceTimersByTime(20000);
-    wrapper.unmount();
+    const animationDuration = 200;
+    const autoPlayIntervalTime = 1000;
+    const props = { autoPlay: true, animationDuration, autoPlayIntervalTime };
+    const wrapperLeft = mount(createCarousel({ ...props, onChange }));
+    const wrapperRight = mount(createCarousel({ ...props, direction: 'right' }));
+
+    jest.advanceTimersByTime(autoPlayIntervalTime);
+    expect(wrapperLeft.state('activeIndex')).toEqual(1);
+    expect(wrapperRight.state('activeIndex')).toEqual(0);
+    expect(onChange).toBeCalledWith(1);
+
+    jest.advanceTimersByTime(10 * autoPlayIntervalTime);
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 
-  it('autoPlay and direction is right', () => {
+  it('loop', () => {
     jest.useFakeTimers();
-    const ITEMS = ['1', '2', '3'];
-    const wrapper = mount(
-      <Carousel autoPlay direction="right">
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
-    );
-    wrapper.setProps({ activeIndex: 1 });
-    jest.advanceTimersByTime(3000);
+    const onChange = jest.fn();
+    const autoPlayIntervalTime = 1000;
+    const props = {
+      loop: true,
+      autoPlay: true,
+      autoPlayIntervalTime,
+      onChange,
+    };
+    const wrapper = mount(createCarousel(props, 2));
+
+    jest.advanceTimersByTime(autoPlayIntervalTime);
+    expect(wrapper.state('activeIndex')).toEqual(1);
+
+    jest.advanceTimersByTime(autoPlayIntervalTime);
+    expect(wrapper.state('activeIndex')).toEqual(0);
+
+    wrapper.setState({ direction: 'right' });
+    jest.advanceTimersByTime(autoPlayIntervalTime);
+    expect(wrapper.state('activeIndex')).toEqual(1);
+
+    jest.advanceTimersByTime(10 * autoPlayIntervalTime);
+    expect(onChange).toHaveBeenCalledTimes(13);
+  });
+
+  it('componentWillReceiveProps', () => {
+    const ITEMS = [1, 2];
+    const wrapper = mount(createCarousel());
+    const children = ITEMS.map((item, index) => {
+      return (
+        <div key={index}>{ item }</div>
+      );
+    });
+
+    wrapper.setProps({ children, activeIndex: 1 });
+    expect(wrapper.state('activeIndex')).toEqual(1);
+    expect(toJson(render(wrapper))).toMatchSnapshot();
+
+    wrapper.setProps({ activeIndex: -1 });
+    expect(wrapper.state('activeIndex')).toEqual(1);
   });
 
   it('touch event', () => {
-    const onChangeEnd = jest.fn();
-    const ITEMS = ['1', '2', '3'];
-    const wrapper = mount(
-      <Carousel onChangeEnd={onChangeEnd} direction="right">
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
-    );
+    const direction = 'right';
+    const props = { direction };
+    const wrapper = mount(createCarousel(props));
 
     wrapper.find('.za-carousel-items')
       .simulate('touchStart', {
@@ -115,18 +158,9 @@ describe('Carousel', () => {
   it('pagination event', () => {
     const onChange = jest.fn();
     const onChangeEnd = jest.fn();
-    const ITEMS = ['1', '2', '3'];
-    const wrapper = mount(
-      <Carousel onChange={onChange} onChangeEnd={onChangeEnd} direction="right">
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
-    );
+    const direction = 'right';
+    const props = { onChange, onChangeEnd, direction };
+    const wrapper = mount(createCarousel(props));
 
     wrapper
       .find('.za-carousel-pagination li')
@@ -138,5 +172,26 @@ describe('Carousel', () => {
         .at(2)
         .hasClass('active')
     ).toBe(true);
+  });
+
+  it('resize event', () => {
+    // reference: https://github.com/airbnb/enzyme/issues/426#issuecomment-225912455
+    const eventMap = {};
+    window.addEventListener = jest.fn((event, cb) => {
+      eventMap[event] = cb;
+    });
+
+    const wrapper = mount(createCarousel());
+    eventMap.resize({ innerWidth: 800 });
+    expect(wrapper.state('activeIndex')).toEqual(0);
+    wrapper.unmount();
+  });
+
+  it('transitionend event', () => {
+    const activeIndex = 1;
+    const onChangeEnd = jest.fn();
+    const wrapper = mount(createCarousel({ activeIndex, onChangeEnd }));
+    wrapper.find('.za-carousel-items').at(0).simulate('transitionend');
+    expect(onChangeEnd).toBeCalledWith(1);
   });
 });

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -353,9 +353,9 @@ export default class Carousel extends Component<CarouselProps, any> {
     );
   }
   render() {
-    const { prefixCls, className, height, showPagination } = this.props;
+    const { prefixCls, className, height, showPagination, style } = this.props;
     const cls = classnames(prefixCls, className);
-    const itemsStyle: CSSProperties = {};
+    const itemsStyle: CSSProperties = { ...style };
 
     if (!this.isDirectionX()) {
       itemsStyle.height = height;

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -89,8 +89,9 @@ export default class Carousel extends Component<CarouselProps, any> {
       return;
     }
 
-    const { loop, children } = this.props;
+    const { loop, children, onChange } = this.props;
     const maxLength = children.length;
+    const previousIndex = this.state.activeIndex;
 
     this.translateX = -dom.offsetWidth * (index + loop);
     this.translateY = -dom.offsetHeight * (index + loop);
@@ -104,6 +105,10 @@ export default class Carousel extends Component<CarouselProps, any> {
     this.setState({
       activeIndex: index,
     });
+
+    if (typeof onChange === 'function' && previousIndex !== index) {
+      onChange(index);
+    }
   }
 
   // 触屏事件
@@ -171,7 +176,6 @@ export default class Carousel extends Component<CarouselProps, any> {
     const {
       moveDistanceRatio = Carousel.defaultProps.moveDistanceRatio,
       moveTimeSpan = Carousel.defaultProps.moveTimeSpan,
-      onChange,
     } = this.props;
     let { activeIndex } = this.state;
 
@@ -186,11 +190,6 @@ export default class Carousel extends Component<CarouselProps, any> {
     // 2.滑动释放时间差低于moveTimeSpan
     if (ratio >= moveDistanceRatio || timeSpan <= moveTimeSpan) {
       const op = !((this.isDirectionX() && offsetX > 0) || (!this.isDirectionX() && offsetY > 0));
-
-      if (typeof onChange === 'function') {
-        onChange(this.parseActiveIndexParse(op));
-      }
-
       activeIndex = op ? activeIndex + 1 : activeIndex - 1;
     }
 
@@ -198,19 +197,6 @@ export default class Carousel extends Component<CarouselProps, any> {
 
     // 恢复自动轮播
     this.startAutoPlay();
-  }
-
-  parseActiveIndexParse = (op) => {
-    const { loop, children } = this.props;
-    const maxIndex = children.length - 1;
-    let { activeIndex } = this.state;
-
-    if (op) {
-      activeIndex = (activeIndex + 1) > maxIndex ? (loop ? 0 : maxIndex) : activeIndex += 1;
-    } else {
-      activeIndex = (activeIndex - 1) < 0 ? (loop ? maxIndex : 0) : activeIndex -= 1;
-    }
-    return activeIndex;
   }
 
   // 自动轮播开始

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -85,9 +85,6 @@ export default class Carousel extends Component<CarouselProps, any> {
   // 移动到指定编号
   onMoveTo = (index, animationDuration) => {
     const dom = this.carouselItems;
-    if (!dom) {
-      return;
-    }
 
     const { loop, children, onChange } = this.props;
     const maxLength = children.length;

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -45,8 +45,8 @@ export default class Carousel extends Component<CarouselProps, any> {
   componentDidMount() {
     // 监听窗口变化
     Events.on(window, 'resize', this.resize);
-    Events.on(this.carouselItems, 'webkitTransitionEnd', this.transitionEnd);
-    Events.on(this.carouselItems, 'transitionend', this.transitionEnd);
+    // Events.on(this.carouselItems, 'webkitTransitionEnd', this.transitionEnd);
+    // Events.on(this.carouselItems, 'transitionend', this.transitionEnd);
 
     // 设置起始位置编号
     this.onJumpTo(this.props.activeIndex);
@@ -365,6 +365,7 @@ export default class Carousel extends Component<CarouselProps, any> {
           <div
             ref={(ele) => { this.carouselItems = ele; }}
             className={`${prefixCls}-items`}
+            onTransitionEnd={this.transitionEnd}
             style={itemsStyle}
           >
             {this.state.items}

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -198,11 +198,10 @@ export default class Carousel extends Component<CarouselProps, any> {
 
   // 自动轮播开始
   startAutoPlay = () => {
-    const { direction = 'left', loop, autoPlay, autoPlayIntervalTime, children } = this.props;
+    const { direction = 'left', loop, autoPlay, autoPlayIntervalTime } = this.props;
 
     this.moveInterval = (autoPlay && setInterval(() => {
       let activeIndex = this.state.activeIndex;
-      const maxLength = children.length;
       const isLeftOrTopDirection = (['left', 'top']).indexOf(direction) > -1;
 
       activeIndex = isLeftOrTopDirection
@@ -210,12 +209,7 @@ export default class Carousel extends Component<CarouselProps, any> {
         : (activeIndex - 1);
 
       // 不循环暂停轮播
-      if (
-        !loop
-          && isLeftOrTopDirection
-            ? activeIndex > maxLength - 1
-            : activeIndex < 0
-      ) {
+      if (!loop && (isLeftOrTopDirection ? this.isLastIndex() : this.isFirstIndex())) {
         this.pauseAutoPlay();
         return;
       }
@@ -230,7 +224,7 @@ export default class Carousel extends Component<CarouselProps, any> {
     }
   }
 
-  // 处理节点（首位拼接）
+  // 处理节点（首尾拼接）
   parseItems = (props) => {
     if (props.children.length === 0) {
       return;
@@ -285,9 +279,9 @@ export default class Carousel extends Component<CarouselProps, any> {
     dom.style.transform = `translate3d(${x}px, ${y}px, 0)`;
   }
 
+  // TODO:bug fix, change every time
   transitionEnd = () => {
     const activeIndex = this.state.activeIndex;
-    // this.props.onChangeEnd!(activeIndex);
     const dom = this.carouselItems;
     this.translateX = -dom.offsetWidth * (activeIndex + this.props.loop);
     this.translateY = -dom.offsetHeight * (activeIndex + this.props.loop);

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -220,13 +220,19 @@ export default class Carousel extends Component<CarouselProps, any> {
     this.moveInterval = (autoPlay && setInterval(() => {
       let activeIndex = this.state.activeIndex;
       const maxLength = children.length;
+      const isLeftOrTopDirection = (['left', 'top']).indexOf(direction) > -1;
 
-      activeIndex = (['left', 'top'].indexOf(direction) > -1)
+      activeIndex = isLeftOrTopDirection
         ? (activeIndex + 1)
         : (activeIndex - 1);
 
       // 不循环暂停轮播
-      if (!loop && activeIndex > maxLength - 1) {
+      if (
+        !loop
+          && isLeftOrTopDirection
+            ? activeIndex > maxLength - 1
+            : activeIndex < 0
+      ) {
         this.pauseAutoPlay();
         return;
       }


### PR DESCRIPTION
- 将 `onChange` 事件触发时机从 `onDragEnd` 方法中移至 `onMoveTo` 以修复自动轮播时未触发`onChange` 回调事件
- 将 `transitionEnd` 事件触发时机移至 prop 属性中以方便单元测试
- 添加对 `style` 的支持
- 单元测试用例更新