### PR TITLE
perf: carousel

### DIFF
--- a/components/carousel/PropsType.tsx
+++ b/components/carousel/PropsType.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, CSSProperties } from 'react';
 
 export default interface PropsType {
   direction?: 'left' | 'right' | 'top' | 'bottom';
@@ -14,4 +14,5 @@ export default interface PropsType {
   onChange?: (activeIndex: number) => void;
   onChangeEnd?: (activeIndex: number) => void;
   children: ReactNode[];
+  style?: CSSProperties;
 }

--- a/components/carousel/__tests__/__snapshots__/index.test.jsx.snap
+++ b/components/carousel/__tests__/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,123 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Carousel loop renders correctly 1`] = `
+exports[`Carousel base render correctly 1`] = `
+<div>
+  <div
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    >
+      <div
+        class="za-carousel-item"
+      >
+        0
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        1
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        2
+      </div>
+    </div>
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul>
+        <li
+          class="active"
+          role="tab"
+          style="display:inline-block"
+        />
+        <li
+          class=""
+          role="tab"
+          style="display:inline-block"
+        />
+        <li
+          class=""
+          role="tab"
+          style="display:inline-block"
+        />
+      </ul>
+    </div>
+  </div>
+  <div
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    />
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul />
+    </div>
+  </div>
+  <div
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    />
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul />
+    </div>
+  </div>
+  <div
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    >
+      <div
+        class="za-carousel-item"
+      >
+        0
+      </div>
+    </div>
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul>
+        <li
+          class="active"
+          role="tab"
+          style="display:inline-block"
+        />
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Carousel className render correctly 1`] = `
+<div
+  class="za-carousel za-wrapper-test"
+>
+  <div
+    class="za-carousel-items"
+    style="white-space:nowrap"
+  />
+  <div
+    class="za-carousel-pagination horizontal"
+  >
+    <ul />
+  </div>
+</div>
+`;
+
+exports[`Carousel componentWillReceiveProps 1`] = `
 <div
   class="za-carousel"
 >
@@ -11,11 +128,6 @@ exports[`Carousel loop renders correctly 1`] = `
     <div
       class="za-carousel-item"
     >
-      3
-    </div>
-    <div
-      class="za-carousel-item"
-    >
       1
     </div>
     <div
@@ -23,33 +135,18 @@ exports[`Carousel loop renders correctly 1`] = `
     >
       2
     </div>
-    <div
-      class="za-carousel-item"
-    >
-      3
-    </div>
-    <div
-      class="za-carousel-item"
-    >
-      1
-    </div>
   </div>
   <div
     class="za-carousel-pagination horizontal"
   >
     <ul>
       <li
+        class=""
+        role="tab"
+        style="display:inline-block"
+      />
+      <li
         class="active"
-        role="tab"
-        style="display:inline-block"
-      />
-      <li
-        class=""
-        role="tab"
-        style="display:inline-block"
-      />
-      <li
-        class=""
         role="tab"
         style="display:inline-block"
       />
@@ -58,14 +155,19 @@ exports[`Carousel loop renders correctly 1`] = `
 </div>
 `;
 
-exports[`Carousel renders correctly 1`] = `
+exports[`Carousel height render correctly 1`] = `
 <div
   class="za-carousel"
 >
   <div
     class="za-carousel-items"
-    style="white-space:nowrap"
+    style="height:150px"
   >
+    <div
+      class="za-carousel-item"
+    >
+      0
+    </div>
     <div
       class="za-carousel-item"
     >
@@ -76,14 +178,118 @@ exports[`Carousel renders correctly 1`] = `
     >
       2
     </div>
+  </div>
+  <div
+    class="za-carousel-pagination vertical"
+  >
+    <ul>
+      <li
+        class="active"
+        role="tab"
+      />
+      <li
+        class=""
+        role="tab"
+      />
+      <li
+        class=""
+        role="tab"
+      />
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`Carousel pagination render correctly 1`] = `
+<div>
+  <div
+    class="za-carousel"
+  >
     <div
-      class="za-carousel-item"
+      class="za-carousel-items"
+      style="white-space:nowrap"
     >
-      3
+      <div
+        class="za-carousel-item"
+      >
+        0
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        1
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        2
+      </div>
+    </div>
+    <div
+      class="za-carousel-pagination horizontal"
+    >
+      <ul>
+        <li
+          class="active"
+          role="tab"
+          style="display:inline-block"
+        />
+        <li
+          class=""
+          role="tab"
+          style="display:inline-block"
+        />
+        <li
+          class=""
+          role="tab"
+          style="display:inline-block"
+        />
+      </ul>
     </div>
   </div>
   <div
-    class="za-carousel-pagination horizontal"
+    class="za-carousel"
+  >
+    <div
+      class="za-carousel-items"
+      style="white-space:nowrap"
+    >
+      <div
+        class="za-carousel-item"
+      >
+        0
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        1
+      </div>
+      <div
+        class="za-carousel-item"
+      >
+        2
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Carousel prefixCls render correctly 1`] = `
+<div
+  class="za-test"
+>
+  <div
+    class="za-test-items"
+    style="white-space:nowrap"
+  >
+    <div
+      class="za-test-item"
+    >
+      0
+    </div>
+  </div>
+  <div
+    class="za-test-pagination horizontal"
   >
     <ul>
       <li
@@ -91,17 +297,23 @@ exports[`Carousel renders correctly 1`] = `
         role="tab"
         style="display:inline-block"
       />
-      <li
-        class=""
-        role="tab"
-        style="display:inline-block"
-      />
-      <li
-        class=""
-        role="tab"
-        style="display:inline-block"
-      />
     </ul>
+  </div>
+</div>
+`;
+
+exports[`Carousel style render correctly 1`] = `
+<div
+  class="za-carousel"
+>
+  <div
+    class="za-carousel-items"
+    style="background:red;white-space:nowrap"
+  />
+  <div
+    class="za-carousel-pagination horizontal"
+  >
+    <ul />
   </div>
 </div>
 `;

--- a/components/carousel/__tests__/index.test.jsx
+++ b/components/carousel/__tests__/index.test.jsx
@@ -1,96 +1,139 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { render, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import Carousel from '../index';
 
+const createCarousel = (props, childrenLen = 3) => {
+  const ITEMS = Array.from({ length: childrenLen }).map((v, i) => i);
+  return (
+    <Carousel {...props}>
+      {
+        ITEMS.map((item, index) => {
+          return (
+            <div key={index}>{ item }</div>
+          );
+        })
+      }
+    </Carousel>
+  );
+};
+
 describe('Carousel', () => {
-  it('renders correctly', () => {
-    const ITEMS = ['1', '2', '3'];
+  it('base render correctly', () => {
     const wrapper = render(
-      <Carousel>
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
+      <div>
+        { createCarousel() }
+        { createCarousel({}, 0) }
+        { createCarousel({ activeIndex: 1 }, 0) }
+        { createCarousel({}, 1) }
+      </div>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
-  it('loop renders correctly', () => {
-    const ITEMS = ['1', '2', '3'];
+  it('style render correctly', () => {
+    const style = { background: 'red' };
+    const wrapper = render(createCarousel({ style }, 0));
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('prefixCls render correctly', () => {
+    const prefixCls = 'za-test';
+    const wrapper = render(createCarousel({ prefixCls }, 1));
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('className render correctly', () => {
+    const className = 'za-wrapper-test';
+    const wrapper = render(createCarousel({ className }, 0));
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('height render correctly', () => {
+    const wrapper = render(createCarousel({ height: 150, direction: 'top' }));
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('pagination render correctly', () => {
     const wrapper = render(
-      <Carousel loop>
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
+      <div>
+        {createCarousel({ showPagination: true })}
+        {createCarousel({ showPagination: false })}
+      </div>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('activeIndex', () => {
+    const wrapper = mount(createCarousel({ activeIndex: 1 }));
+    expect(wrapper.state('activeIndex')).toEqual(1);
   });
 
   it('autoPlay', () => {
     jest.useFakeTimers();
-    const ITEMS = ['1', '2', '3'];
     const onChange = jest.fn();
-    const wrapper = mount(
-      <Carousel
-        autoPlay
-        onChange={onChange}
-      >
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
-    );
-    wrapper.setProps({ activeIndex: 1 });
-    jest.advanceTimersByTime(20000);
-    wrapper.unmount();
+    const animationDuration = 200;
+    const autoPlayIntervalTime = 1000;
+    const props = { autoPlay: true, animationDuration, autoPlayIntervalTime };
+    const wrapperLeft = mount(createCarousel({ ...props, onChange }));
+    const wrapperRight = mount(createCarousel({ ...props, direction: 'right' }));
+
+    jest.advanceTimersByTime(autoPlayIntervalTime);
+    expect(wrapperLeft.state('activeIndex')).toEqual(1);
+    expect(wrapperRight.state('activeIndex')).toEqual(0);
+    expect(onChange).toBeCalledWith(1);
+
+    jest.advanceTimersByTime(10 * autoPlayIntervalTime);
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 
-  it('autoPlay and direction is right', () => {
+  it('loop', () => {
     jest.useFakeTimers();
-    const ITEMS = ['1', '2', '3'];
-    const wrapper = mount(
-      <Carousel autoPlay direction="right">
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
-    );
-    wrapper.setProps({ activeIndex: 1 });
-    jest.advanceTimersByTime(3000);
+    const onChange = jest.fn();
+    const autoPlayIntervalTime = 1000;
+    const props = {
+      loop: true,
+      autoPlay: true,
+      autoPlayIntervalTime,
+      onChange,
+    };
+    const wrapper = mount(createCarousel(props, 2));
+
+    jest.advanceTimersByTime(autoPlayIntervalTime);
+    expect(wrapper.state('activeIndex')).toEqual(1);
+
+    jest.advanceTimersByTime(autoPlayIntervalTime);
+    expect(wrapper.state('activeIndex')).toEqual(0);
+
+    wrapper.setState({ direction: 'right' });
+    jest.advanceTimersByTime(autoPlayIntervalTime);
+    expect(wrapper.state('activeIndex')).toEqual(1);
+
+    jest.advanceTimersByTime(10 * autoPlayIntervalTime);
+    expect(onChange).toHaveBeenCalledTimes(13);
+  });
+
+  it('componentWillReceiveProps', () => {
+    const ITEMS = [1, 2];
+    const wrapper = mount(createCarousel());
+    const children = ITEMS.map((item, index) => {
+      return (
+        <div key={index}>{ item }</div>
+      );
+    });
+
+    wrapper.setProps({ children, activeIndex: 1 });
+    expect(wrapper.state('activeIndex')).toEqual(1);
+    expect(toJson(render(wrapper))).toMatchSnapshot();
+
+    wrapper.setProps({ activeIndex: -1 });
+    expect(wrapper.state('activeIndex')).toEqual(1);
   });
 
   it('touch event', () => {
-    const onChangeEnd = jest.fn();
-    const ITEMS = ['1', '2', '3'];
-    const wrapper = mount(
-      <Carousel onChangeEnd={onChangeEnd} direction="right">
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
-    );
+    const direction = 'right';
+    const props = { direction };
+    const wrapper = mount(createCarousel(props));
 
     wrapper.find('.za-carousel-items')
       .simulate('touchStart', {
@@ -115,18 +158,9 @@ describe('Carousel', () => {
   it('pagination event', () => {
     const onChange = jest.fn();
     const onChangeEnd = jest.fn();
-    const ITEMS = ['1', '2', '3'];
-    const wrapper = mount(
-      <Carousel onChange={onChange} onChangeEnd={onChangeEnd} direction="right">
-        {
-          ITEMS.map((item, i) => {
-            return (
-              <div key={+i}>{item}</div>
-            );
-          })
-        }
-      </Carousel>
-    );
+    const direction = 'right';
+    const props = { onChange, onChangeEnd, direction };
+    const wrapper = mount(createCarousel(props));
 
     wrapper
       .find('.za-carousel-pagination li')
@@ -138,5 +172,26 @@ describe('Carousel', () => {
         .at(2)
         .hasClass('active')
     ).toBe(true);
+  });
+
+  it('resize event', () => {
+    // reference: https://github.com/airbnb/enzyme/issues/426#issuecomment-225912455
+    const eventMap = {};
+    window.addEventListener = jest.fn((event, cb) => {
+      eventMap[event] = cb;
+    });
+
+    const wrapper = mount(createCarousel());
+    eventMap.resize({ innerWidth: 800 });
+    expect(wrapper.state('activeIndex')).toEqual(0);
+    wrapper.unmount();
+  });
+
+  it('transitionend event', () => {
+    const activeIndex = 1;
+    const onChangeEnd = jest.fn();
+    const wrapper = mount(createCarousel({ activeIndex, onChangeEnd }));
+    wrapper.find('.za-carousel-items').at(0).simulate('transitionend');
+    expect(onChangeEnd).toBeCalledWith(1);
   });
 });

--- a/components/carousel/__tests__/index.test.jsx
+++ b/components/carousel/__tests__/index.test.jsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react';
+import React from 'react';
 import { render, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import Carousel from '../index';
@@ -128,18 +128,108 @@ describe('Carousel', () => {
 
     wrapper.setProps({ activeIndex: -1 });
     expect(wrapper.state('activeIndex')).toEqual(1);
+
+    wrapper.setProps({ activeIndex: 10 });
+    expect(wrapper.state('activeIndex')).toEqual(0);
   });
 
-  it('touch event', () => {
-    const direction = 'right';
-    const props = { direction };
-    const wrapper = mount(createCarousel(props));
+  it('touchStart', () => {
+    const wrapper = mount(createCarousel());
+    const wrapperTouchStart = (wrapperTouch) => {
+      wrapperTouch
+        .find('.za-carousel-items')
+        .simulate('touchStart', {
+          touches: [
+            {
+              pageX: 0,
+            },
+          ],
+        });
+    };
+    wrapperTouchStart(wrapper);
+    expect(wrapper.state('activeIndex')).toEqual(0);
 
+    wrapper.setProps({ activeIndex: 2 });
+    wrapperTouchStart(wrapper);
+    expect(wrapper.state('activeIndex')).toEqual(2);
+  });
+
+  it('touchMove', () => {
+    const wrapperDirectionX = mount(createCarousel());
+    const wrapperDirectionY = mount(createCarousel({ direction: 'bottom' }));
+    const wrapperTouchMove = (wrapper) => {
+      wrapper.find('.za-carousel-items')
+        .simulate('touchStart', {
+          touches: [
+            {
+              pageX: 0,
+              pageY: 0,
+            },
+          ],
+        })
+        .simulate('touchMove', {
+          touches: [
+            {
+              pageX: -4,
+              pageY: 0,
+            },
+          ],
+        })
+        .simulate('touchMove', {
+          touches: [
+            {
+              pageX: -5,
+              pageY: 0,
+            },
+          ],
+        })
+        .simulate('touchMove', {
+          touches: [
+            {
+              pageX: 4,
+              pageY: 0,
+            },
+          ],
+        })
+        .simulate('touchMove', {
+          touches: [
+            {
+              pageX: 4,
+              pageY: 4,
+            },
+          ],
+        })
+        .simulate('touchMove', {
+          touches: [
+            {
+              pageX: 4,
+              pageY: 4 + 5,
+            },
+          ],
+        });
+    };
+
+    Array.of(wrapperDirectionX, wrapperDirectionY).forEach((wrapper) => {
+      wrapperTouchMove(wrapper);
+      expect(wrapper.state('activeIndex')).toEqual(0);
+
+      wrapper.setProps({ activeIndex: 2 });
+      wrapperTouchMove(wrapper);
+      expect(wrapper.state('activeIndex')).toEqual(2);
+    });
+  });
+
+  it('touchEnd', () => {
+    const moveDistanceRatio = 1;
+    const moveTimeSpan = 200;
+    const props = { moveDistanceRatio, moveTimeSpan };
+    const wrapper = mount(createCarousel(props));
     wrapper.find('.za-carousel-items')
       .simulate('touchStart', {
         touches: [
           {
             pageX: 0,
+            pageY: 0,
           },
         ],
       })
@@ -147,31 +237,12 @@ describe('Carousel', () => {
         touches: [
           {
             pageX: 100,
+            pageY: 100,
           },
         ],
       })
+      // TODO: touchEnd callback not contain offsetX and offsetY props
       .simulate('touchEnd');
-
-    expect(wrapper.state('activeIndex')).toEqual(0);
-  });
-
-  it('pagination event', () => {
-    const onChange = jest.fn();
-    const onChangeEnd = jest.fn();
-    const direction = 'right';
-    const props = { onChange, onChangeEnd, direction };
-    const wrapper = mount(createCarousel(props));
-
-    wrapper
-      .find('.za-carousel-pagination li')
-      .at(2)
-      .simulate('click');
-    expect(
-      wrapper
-        .find('.za-carousel-pagination li')
-        .at(2)
-        .hasClass('active')
-    ).toBe(true);
   });
 
   it('resize event', () => {
@@ -188,9 +259,9 @@ describe('Carousel', () => {
   });
 
   it('transitionend event', () => {
-    const activeIndex = 1;
     const onChangeEnd = jest.fn();
-    const wrapper = mount(createCarousel({ activeIndex, onChangeEnd }));
+    const wrapper = mount(createCarousel({ onChangeEnd }));
+    wrapper.find('.za-carousel-pagination li').at(1).simulate('click');
     wrapper.find('.za-carousel-items').at(0).simulate('transitionend');
     expect(onChangeEnd).toBeCalledWith(1);
   });

--- a/components/carousel/__tests__/index.test.jsx
+++ b/components/carousel/__tests__/index.test.jsx
@@ -224,25 +224,43 @@ describe('Carousel', () => {
     const moveTimeSpan = 200;
     const props = { moveDistanceRatio, moveTimeSpan };
     const wrapper = mount(createCarousel(props));
-    wrapper.find('.za-carousel-items')
-      .simulate('touchStart', {
-        touches: [
-          {
-            pageX: 0,
-            pageY: 0,
-          },
-        ],
-      })
-      .simulate('touchMove', {
-        touches: [
-          {
-            pageX: 100,
-            pageY: 100,
-          },
-        ],
-      })
-      // TODO: touchEnd callback not contain offsetX and offsetY props
-      .simulate('touchEnd');
+    const wrapperTouchEnd = ({
+      direction = 'left',
+      offset = 100,
+      activeIndex = 0,
+    }) => {
+      wrapper
+        .setProps({ direction, activeIndex })
+        .find('.za-carousel-items')
+        .simulate('touchStart', {
+          touches: [
+            {
+              pageX: 0,
+              pageY: 0,
+            },
+          ],
+        })
+        .simulate('touchMove', {
+          touches: [
+            {
+              pageX: ['left', 'right'].includes(direction) ? offset : 0,
+              pageY: ['top', 'bottom'].includes(direction) ? offset : 0,
+            },
+          ],
+        })
+        .simulate('touchEnd');
+    };
+    wrapperTouchEnd({ offset: 0 });
+    expect(wrapper.state('activeIndex')).toEqual(0);
+
+    wrapperTouchEnd({ offset: -100 });
+    expect(wrapper.state('activeIndex')).toEqual(1);
+
+    wrapperTouchEnd({ activeIndex: 1, offset: 100 });
+    expect(wrapper.state('activeIndex')).toEqual(0);
+
+    wrapperTouchEnd({ direction: 'top', offset: -100 });
+    expect(wrapper.state('activeIndex')).toEqual(1);
   });
 
   it('resize event', () => {

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -34,6 +34,7 @@ export default class Carousel extends Component<CarouselProps, any> {
     this.state = {
       items: [],
       activeIndex: props.activeIndex,
+      activeIndexChanged: false,
     };
   }
 
@@ -99,11 +100,13 @@ export default class Carousel extends Component<CarouselProps, any> {
     } else if (index < 0) {
       index = maxLength - 1;
     }
+    const activeIndexChanged = previousIndex !== index;
     this.setState({
       activeIndex: index,
+      activeIndexChanged,
     });
 
-    if (typeof onChange === 'function' && previousIndex !== index) {
+    if (typeof onChange === 'function' && activeIndexChanged) {
       onChange(index);
     }
   }
@@ -138,7 +141,7 @@ export default class Carousel extends Component<CarouselProps, any> {
 
     // 设置不循环的时候
     if (!this.props.loop) {
-      // 在首页时禁止拖动
+      // 在尾页时禁止拖动
       if (this.isLastIndex()) {
         if (
           this.isDirectionX() && offsetX < 0 ||
@@ -148,7 +151,7 @@ export default class Carousel extends Component<CarouselProps, any> {
         }
       }
 
-      // 在尾页时禁止拖动
+      // 在首页时禁止拖动
       if (this.isFirstIndex()) {
         if (
           this.isDirectionX() && offsetX > 0 ||
@@ -284,7 +287,6 @@ export default class Carousel extends Component<CarouselProps, any> {
     dom.style.transform = `translate3d(${x}px, ${y}px, 0)`;
   }
 
-  // TODO:bug fix, change every time
   transitionEnd = () => {
     const activeIndex = this.state.activeIndex;
     const dom = this.carouselItems;
@@ -294,7 +296,7 @@ export default class Carousel extends Component<CarouselProps, any> {
     this.doTransition({ x: this.translateX, y: this.translateY }, 0);
 
     const { onChangeEnd } = this.props;
-    if (typeof onChangeEnd === 'function') {
+    if (typeof onChangeEnd === 'function' && this.state.activeIndexChanged) {
       onChangeEnd(activeIndex);
     }
   }


### PR DESCRIPTION
- 将 `onChange` 事件触发时机从 `onDragEnd` 方法中移至 `onMoveTo` 以修复自动轮播时未触发`onChange` 回调事件
- 将 `transitionEnd` 事件触发时机移至 prop 属性中以方便单元测试
- 修复 `onTouchMove` 但 `activeIndex` 未改变的场景下，`transitionEnd` 事件也触发的 bug
- 添加对 `style` 的支持
- 提升单元测试覆盖率至 90% +
- 错别字更正